### PR TITLE
SEGYStream: more generic ReadableByteChannel instead of FileChannel

### DIFF
--- a/src/main/java/sigrun/common/SEGYStream.java
+++ b/src/main/java/sigrun/common/SEGYStream.java
@@ -10,7 +10,7 @@ import sigrun.serialization.TraceHeaderReader;
 import java.io.Closeable;
 import java.io.IOException;
 import java.nio.ByteBuffer;
-import java.nio.channels.FileChannel;
+import java.nio.channels.ReadableByteChannel;
 import java.util.Collection;
 import java.util.HashSet;
 import java.util.Iterator;
@@ -21,19 +21,17 @@ import java.util.Set;
  */
 public class SEGYStream implements Iterable<SeismicTrace>, Closeable {
     private static final Logger log = LoggerFactory.getLogger(SEGYStream.class);
-    private final FileChannel chan;
+	private final ReadableByteChannel chan;
     private final TraceHeaderReader traceHeaderReader;
-    private final long totalSize;
+	private long totalSize;
     private TextHeader textHeader;
     private BinaryHeader binaryHeader;
     private long position = 0;
     private Set<ParseProgressListener> listeners = new HashSet<ParseProgressListener>();
     private SeismicTrace nextTrace;
 
-    protected SEGYStream(FileChannel chan,
-                         TextHeaderReader textHeaderReader,
-                         BinaryHeaderReader binaryHeaderReader,
-                         TraceHeaderReader traceHeaderReader,
+	protected SEGYStream(ReadableByteChannel chan, TextHeaderReader textHeaderReader,
+			BinaryHeaderReader binaryHeaderReader, TraceHeaderReader traceHeaderReader,
                          Collection<ParseProgressListener> listeners) {
         this.position = 0;
         this.listeners.addAll(listeners);
@@ -48,16 +46,9 @@ public class SEGYStream implements Iterable<SeismicTrace>, Closeable {
 
         this.traceHeaderReader = traceHeaderReader;
         this.chan = chan;
-
-        try {
-            this.totalSize = chan.size();
-        } catch (IOException e) {
-            log.error(e.getLocalizedMessage());
-            throw new SEGYStreamException(e);
-        }
     }
 
-    private void readTextHeader(FileChannel chan, TextHeaderReader textHeaderReader) throws IOException {
+	private void readTextHeader(ReadableByteChannel chan, TextHeaderReader textHeaderReader) throws IOException {
         ByteBuffer buf = ByteBuffer.allocate(TextHeader.TEXT_HEADER_SIZE);
 
         if (chan.read(buf) != TextHeader.TEXT_HEADER_SIZE) {
@@ -70,7 +61,7 @@ public class SEGYStream implements Iterable<SeismicTrace>, Closeable {
         assert this.position == TextHeader.TEXT_HEADER_SIZE;
     }
 
-    private void readBinaryHeader(FileChannel chan, BinaryHeaderReader binaryHeaderReader) throws IOException {
+	private void readBinaryHeader(ReadableByteChannel chan, BinaryHeaderReader binaryHeaderReader) throws IOException {
         ByteBuffer buf = ByteBuffer.allocate(BinaryHeader.BIN_HEADER_LENGTH);
 
         if (chan.read(buf) != BinaryHeader.BIN_HEADER_LENGTH) {

--- a/src/main/java/sigrun/common/SEGYStreamFactory.java
+++ b/src/main/java/sigrun/common/SEGYStreamFactory.java
@@ -3,7 +3,7 @@ package sigrun.common;
 import sigrun.serialization.*;
 
 import java.io.FileInputStream;
-import java.nio.channels.FileChannel;
+import java.nio.channels.ReadableByteChannel;
 import java.nio.charset.Charset;
 import java.util.Collection;
 import java.util.Collections;
@@ -31,11 +31,11 @@ public class SEGYStreamFactory {
         return new SEGYStreamFactory(charset, binaryHeaderFormat, traceHeaderFormat);
     }
 
-    public SEGYStream makeStream(FileChannel chan) {
+    public SEGYStream makeStream(ReadableByteChannel chan) {
         return makeStream(chan, Collections.<ParseProgressListener>emptySet());
     }
 
-    public SEGYStream makeStream(FileChannel chan, Collection<ParseProgressListener> listeners) {
+    public SEGYStream makeStream(ReadableByteChannel chan, Collection<ParseProgressListener> listeners) {
         return new SEGYStream(chan, textHeaderReader, binaryHeaderReader, traceHeaderReader, listeners);
     }
 
@@ -44,8 +44,6 @@ public class SEGYStreamFactory {
     }
 
     public SEGYStream makeStream(FileInputStream fileInputStream, Collection<ParseProgressListener> listeners) {
-        final FileChannel chan = fileInputStream.getChannel();
-
-        return new SEGYStream(chan, textHeaderReader, binaryHeaderReader, traceHeaderReader, listeners);
+        return new SEGYStream(fileInputStream.getChannel(), textHeaderReader, binaryHeaderReader, traceHeaderReader, listeners);
     }
 }

--- a/src/main/java/sigrun/reports/NavigationStrategy.java
+++ b/src/main/java/sigrun/reports/NavigationStrategy.java
@@ -3,7 +3,6 @@ package sigrun.reports;
 import sigrun.common.BinaryHeader;
 import sigrun.common.TextHeader;
 import sigrun.common.TraceHeader;
-import sun.reflect.generics.reflectiveObjects.NotImplementedException;
 
 import java.io.IOException;
 import java.io.OutputStream;
@@ -37,6 +36,6 @@ public class NavigationStrategy extends ReportStrategy {
 
     @Override
     public void printHeader(OutputStream outputStream) throws IOException {
-        throw new NotImplementedException();
+        throw new UnsupportedOperationException("NavigationStrategy.printHeader not yet implemented.");
     }
 }

--- a/src/main/java/sigrun/reports/PetrobankNavigationStrategy.java
+++ b/src/main/java/sigrun/reports/PetrobankNavigationStrategy.java
@@ -4,6 +4,8 @@ import sigrun.common.TraceHeader;
 
 import java.io.IOException;
 import java.io.OutputStream;
+import java.util.Formatter;
+import java.util.Locale;
 
 @SuppressWarnings("UnusedDeclaration")
 public class PetrobankNavigationStrategy extends ReportStrategy {
@@ -28,15 +30,16 @@ public class PetrobankNavigationStrategy extends ReportStrategy {
 
     @Override
     public void processTraceHeader(TraceHeader traceHeader, OutputStream outputStream) throws IOException {
-        String result = String.format(NAVIGATION_FORMAT,
+    	
+    	Formatter formatter = new Formatter(outputStream,"UTF-8", Locale.getDefault());
+    	formatter.format(NAVIGATION_FORMAT,
                 RECORD_PREFIX,
                 counter++,
                 traceHeader.getSourceX(),
                 traceHeader.getSourceY(),
                 getShotPointNumber(traceHeader),
                 binaryHeader.getLineNumber());
-
-        outputStream.write(result.getBytes("UTF-8"));
+    	formatter.flush();
     }
 
     private int getShotPointNumber(TraceHeader traceHeader) {


### PR DESCRIPTION
- SEGYParser: now we use a more generic ReadableByteChannel instead of FileChannel
- Removed proprietary JAR (sun.generic)
- String.format replaced by Formatter (before it was not matching Apache Tika requirements)